### PR TITLE
Remove ability to have auditor run commands

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -121,5 +121,8 @@ function ordersSnapshot (req, res) {
   })
 }
 
-const instance = Server().listen(process.env.PORT || '3000')
-process.on('SIGINT', () => instance.close())
+if (require.main === module) {
+  const instance = Server().listen(process.env.PORT || '3000')
+  process.on('SIGINT', () => instance.close())
+  process.on('SIGTERM', () => instance.close())
+}

--- a/example/index.js
+++ b/example/index.js
@@ -126,3 +126,5 @@ if (require.main === module) {
   process.on('SIGINT', () => instance.close())
   process.on('SIGTERM', () => instance.close())
 }
+
+module.exports = Server

--- a/lib/audit/index.js
+++ b/lib/audit/index.js
@@ -82,6 +82,7 @@ function auditCommand (command, options) {
         resolve()
       })
       console.log('killing')
+      child.stdin.pause()
       child.kill()
     })
 

--- a/lib/audit/index.js
+++ b/lib/audit/index.js
@@ -17,10 +17,13 @@ module.exports = async function (options) {
       await auditURL(endpoint)
     } else {
       await auditCommand(endpoint, options.slice(1))
+      console.log('auditCommand completed')
     }
   } catch (err) {
+    console.log('caught', err)
     process.exit(1)
   }
+  console.log('done')
 }
 
 function auditURL (u) {
@@ -80,6 +83,8 @@ function auditCommand (command, options) {
       console.log('killing')
       child.kill()
     })
+
+    console.log('server exited', 'error:', err)
 
     if (err) {
       reject(err)

--- a/lib/audit/index.js
+++ b/lib/audit/index.js
@@ -67,6 +67,7 @@ function auditCommand (command, options) {
 
     await new Promise((resolve, reject) => {
       child.on('exit', resolve)
+      child.on('close', resolve)
       child.kill()
     })
 

--- a/lib/audit/index.js
+++ b/lib/audit/index.js
@@ -1,6 +1,3 @@
-const url = require('url')
-const { spawn } = require('child_process')
-const net = require('net')
 const teenytest = require('teenytest')
 
 module.exports = async function (options) {
@@ -8,23 +5,12 @@ module.exports = async function (options) {
     console.log('audit requires at least one argument: a url to and endpoint or a script file to run as an endpoint.')
     process.exit(1)
   }
-  const endpoint = options[0]
-
-  const u = url.parse(endpoint)
-
   try {
-    if (u.protocol) {
-      await auditURL(endpoint)
-    } else {
-      await auditCommand(endpoint, options.slice(1))
-      console.log('auditCommand completed')
-    }
+    await auditURL(options[0])
   } catch (err) {
-    console.log('caught', err)
+    console.log(err)
     process.exit(1)
   }
-  console.log('done')
-  process.exit(0)
 }
 
 function auditURL (u) {
@@ -38,84 +24,5 @@ function auditURL (u) {
         resolve()
       }
     })
-  })
-}
-
-function auditCommand (command, options) {
-  const parts = command.split(' ')
-  const child = spawn(parts[0], parts.slice(1))
-
-  let path = ''
-  if (options.length > 0) {
-    path = options[0]
-  }
-
-  child.stdout.on('data', (data) => console.log(`server: ${data}`))
-  child.stderr.on('data', (data) => console.log(`server: ${data}`))
-
-  return new Promise(async (resolve, reject) => {
-    child.on('error', (err) => {
-      console.log('process error', 'error:', err)
-      reject(err)
-    })
-
-    const port = process.env.PORT || '3000'
-    const p = await ping()
-    if (p instanceof Error) {
-      reject(p)
-    }
-
-    let err
-    try {
-      err = await auditURL(`http://localhost:${port}${path}`)
-    } catch (e) {
-      err = e
-    }
-
-    await new Promise((resolve, reject) => {
-      child.on('exit', (code, signal) => {
-        console.log('process exit', 'code:', code, 'signal:', signal)
-        resolve()
-      })
-      child.on('close', (code, signal) => {
-        console.log('process close', 'code:', code, 'signal:', signal)
-        resolve()
-      })
-      console.log('killing')
-      child.stdin.pause()
-      child.kill()
-    })
-
-    console.log('server exited', 'error:', err)
-
-    if (err) {
-      reject(err)
-    } else {
-      resolve()
-    }
-  })
-}
-
-async function ping (attempt = 0, sleepTime = 1000) {
-  const port = process.env.PORT || '3000'
-
-  try {
-    await new Promise((resolve, reject) => {
-      const s = net.createConnection({port}, resolve)
-      s.on('error', reject)
-    })
-  } catch (e) {
-    if (attempt < 3) {
-      console.log(`Failed to connect to server on localhost:${port}, retry in ${sleepTime}ms`)
-      await sleep(sleepTime)
-      return ping(attempt + 1, sleepTime * 2)
-    }
-    return e
-  }
-}
-
-async function sleep (time) {
-  return new Promise((resolve, reject) => {
-    setTimeout(resolve, time)
   })
 }

--- a/lib/audit/index.js
+++ b/lib/audit/index.js
@@ -24,6 +24,7 @@ module.exports = async function (options) {
     process.exit(1)
   }
   console.log('done')
+  process.exit(0)
 }
 
 function auditURL (u) {

--- a/lib/audit/index.js
+++ b/lib/audit/index.js
@@ -50,7 +50,10 @@ function auditCommand (command, options) {
   child.stderr.on('data', (data) => console.log(`server: ${data}`))
 
   return new Promise(async (resolve, reject) => {
-    child.on('error', reject)
+    child.on('error', (err) => {
+      console.log('process error', 'error:', err)
+      reject(err)
+    })
 
     const port = process.env.PORT || '3000'
     const p = await ping()
@@ -66,8 +69,15 @@ function auditCommand (command, options) {
     }
 
     await new Promise((resolve, reject) => {
-      child.on('exit', resolve)
-      child.on('close', resolve)
+      child.on('exit', (code, signal) => {
+        console.log('process exit', 'code:', code, 'signal:', signal)
+        resolve()
+      })
+      child.on('close', (code, signal) => {
+        console.log('process close', 'code:', code, 'signal:', signal)
+        resolve()
+      })
+      console.log('killing')
       child.kill()
     })
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "cli": "node bin/nomics-platform.js",
     "lint": "eslint **/*.js",
-    "test": "yarn cli audit \"node ./example/index.js\""
+    "test": "node test.js"
   },
   "devDependencies": {
     "eslint": "^5.0.1",

--- a/test.js
+++ b/test.js
@@ -1,0 +1,9 @@
+const audit = require('./lib/audit')
+const Server = require('./example');
+
+(async function test () {
+  const port = process.env.PORT || '3000'
+  const instance = Server().listen(port)
+  await audit([`http://localhost:${port}`])
+  instance.close()
+})()


### PR DESCRIPTION
Initially we added the ability to have the auditor run a server command, but the process management was very error prone, so we are removing this feature. A user of the auditor can either manage their own server process in development, or use the auditor as a library if they are using nodejs (as the auditor now does to test itself).