### PR TITLE
increase timeout and allow trade by timestamp overlaps

### DIFF
--- a/lib/audit/index.js
+++ b/lib/audit/index.js
@@ -17,7 +17,7 @@ function auditURL (u) {
   return new Promise((resolve, reject) => {
     process.chdir(__dirname)
     process.env.NOMICS_PLATFORM_URL_ROOT = u
-    teenytest('test/*.js', { plugins: ['teenytest-promise'], timeout: 30000 }, (err, passing) => {
+    teenytest('test/*.js', { plugins: ['teenytest-promise'], asyncTimeout: 30000 }, (err, passing) => {
       if (err || !passing) {
         reject(new Error('Audit Failed'))
       } else {

--- a/lib/audit/index.js
+++ b/lib/audit/index.js
@@ -17,7 +17,7 @@ function auditURL (u) {
   return new Promise((resolve, reject) => {
     process.chdir(__dirname)
     process.env.NOMICS_PLATFORM_URL_ROOT = u
-    teenytest('test/*.js', { plugins: ['teenytest-promise'] }, (err, passing) => {
+    teenytest('test/*.js', { plugins: ['teenytest-promise'], timeout: 30000 }, (err, passing) => {
       if (err || !passing) {
         reject(new Error('Audit Failed'))
       } else {

--- a/lib/audit/test/audit.js
+++ b/lib/audit/test/audit.js
@@ -115,8 +115,8 @@ module.exports = {
     const second = await au.get(`/trades-by-timestamp?market=${encodeURIComponent(market.id)}&since=${encodeURIComponent(since)}`)
     au.assert(second.length > 0, `Trades with since=${since} didn't return any trades`)
     au.assert(
-      !second.find((t) => t.id === trades[0].id),
-      `Trades with since=${trades[0].id} contained a trade with the same id as the since parameter. Only trades *after* the since id should be returned`
+      !second.find((t) => t.timestamp < trades[0].timestamp),
+      `Trades with since=${trades[0].id} contained a trade with a timestamp before the since parameter. Only trades *after or equal to* the since id should be returned`
     )
     au.assert(
       second.find((t) => t.id === trades[1].id),


### PR DESCRIPTION
Increase timeout to 30 seconds for slow apis.

Also, allow overlap when fetching trades by timestamp since multiple trades could have the same timestamp.