### PR TITLE
Add specification and auditor for `/candles`

### DIFF
--- a/doc/cryptocurrency-api-exchange-integration.md
+++ b/doc/cryptocurrency-api-exchange-integration.md
@@ -221,7 +221,7 @@ The `/candles` endpoint returns open, high, low, close, and volume data for a gi
 
 ### Response
 
-JSON array of OHLCV Candles for the given market and interval. If daily candles are available, as many as possible should be returned (preferably to inception). Otherwise, a fixed 24 hour, 1 hour, or 1 minute ticker should be returned as the only "candle". Timestamps should be aligned to candle size. IE: Midnight UTC (`2018-01-01T:00:00:00.000Z`) for `1d`, to the hour (`2018-01-01T03:00:00.000Z`) for `1h`, and to the minute (`2018-01-01T03:03:00.000Z`) for `1m`. Candles have the following properties:
+JSON array of OHLCV Candles for the given market and interval. If daily candles are available, as many as possible should be returned (preferably to inception). Otherwise, candles should be returned fixed 24 hour, 1 hour, or 1 minute intervals. Timestamps should be aligned to candle size. IE: Midnight UTC (`2018-01-01T:00:00:00.000Z`) for `1d`, to the hour (`2018-01-01T03:00:00.000Z`) for `1h`, and to the minute (`2018-01-01T03:03:00.000Z`) for `1m`. Candles should be sorted by timestamp ascending with the last candle being the current "open" candle for the given interval. Candles have the following properties:
 
 - `timestamp` **Required** timestamp of the start of the candle in RFC3339 aligned to candle size in UTC
 - `close` **Required** close price of the asset in the quote currency as a string parseable to a positive number

--- a/doc/cryptocurrency-api-exchange-integration.md
+++ b/doc/cryptocurrency-api-exchange-integration.md
@@ -230,6 +230,12 @@ JSON array of OHLCV Candles for the given market and interval. If daily candles 
 - `low` **Required** lowest price of the asset in the quote currency as a string parseable to a positive number
 - `volume` **Required** volume of the asset in the base currency as a string parseable to a positive number
 
+Candles are expected to include a minimum number of records for a given interval:
+
+- `1d`: 7 candles
+- `1h`: 24 candles
+- `1m`: 60 candles
+
 ## `/trades-by-timestamp` - Historical Executed Trades Paged by Timestamp - **Discouraged**
 
 The `/trades-by-timestamp` endpoint is nearly identical to the `/trades` endpoint. The core difference is that the `since` parameter is an RFC3339 timestamp instead of an ID. Otherwise, the parameters and response are the same.

--- a/doc/cryptocurrency-api-exchange-integration.md
+++ b/doc/cryptocurrency-api-exchange-integration.md
@@ -36,7 +36,7 @@ JSON object containing the following properties:
   * `orders`: boolean indicating orders endpoint is implemented
   * `ordersSocket`: boolean indicating orders socket endpoint is implemented
   * `ordersSnapshot`: boolean indicating orders snapshot endpoint is implemented
-  * `candles`: boolean indicating candles endpoint is implemented
+  - `candles`: array indicating which intervals the candles endpoint implements. Valid values are `1d` (required), `1h`, and `1m`.
 
 Example:
 
@@ -54,7 +54,7 @@ Example:
     "orders": false,
     "ordersSocket": false,
     "ordersSnapshot": false,
-    "candles": false
+    "candles": ["1d", "1h"]
   }
 }
 ```
@@ -206,33 +206,30 @@ Bids **must be sorted in descending order** and asks **must be sorted in ascendi
 
 When returning orders, perform as little aggregation as possible (ideally none) and include as many orders as possible (ideally all).
 
-## `/candles` - Candles or 24h Ticker - **Discouraged**
+## `/candles` - Candles - **Optional**
 
 **If you implement `/trades` you do not need to implement `/candles`.**
 
-The `/candles` endpoint returns open, high, low, close, and volume data for a given market in a 24 hour period. It allows Nomics to get a 24 hour picture of a market, as well as a high level historical view when available.
-
-It is designed to be compatible with 24 hour tickers present on many exchanges as well as candle data present on some exchanges.
+The `/candles` endpoint returns open, high, low, close, and volume data for a given market in 24 hour, 1 hour, and/or 1 minute periods. It allows Nomics to get at least a 24 hour picture of a market, as well as a high level historical view when available. Implementing this endpoint requires at least the `1d` candle interval with `1h` and `1m` being additionally optional.
 
 **We highly recommend implementing the `/trades` endpoint instead of the `/candles` endpoint.** The `/candles` endpoint should be used as a last resort if implementing `/trades` is not possible.
 
 ### Parameters
 
-* `market` **Required** A market ID from the `/markets` endpoint
+- `market` **Required** A market ID from the `/markets` endpoint.
+- `interval` **Required** The interval of the OHLCV candles. Valid values are `1d` (required), `1h`, and `1m`.
 
 ### Response
 
-JSON array of OHLCV Candles for the given market. If daily candles are available, as many as possible should be returned (preferably to inception). Otherwise, a sliding 24 hour ticker should be returned as the only "candle". Candles have the following properties:
+JSON array of OHLCV Candles for the given market and interval. If daily candles are available, as many as possible should be returned (preferably to inception). Otherwise, a sliding 24 hour, 1 hour, or 1 minute ticker should be returned as the only "candle". Candles have the following properties:
 
-* `timestamp` **Required** timestamp of the candle in RFC3339
-* `close` **Required** close price of the asset in the quote currency as a string parseable to a positive number
-* `open` open price of the asset in the quote currency as a string parseable to a positive number
-* `high` highest price of the asset in the quote currency as a string parseable to a positive number
-* `low` lowest price of the asset in the quote currency as a string parseable to a positive number
-* `volume` volume of the asset in the base currency as a string parseable to a positive number
-* `vwap` volume weighted average price of the asset in the quote currency as a string parseable to a positive number
-
-Only `timestamp` and `close` are required so that this endpoint is compatible with as many existing APIs as possible. However, we strongly recommend including all properties.
+- `timestamp` **Required** timestamp of the candle in RFC3339
+- `close` **Required** close price of the asset in the quote currency as a string parseable to a positive number
+- `open` **Required** open price of the asset in the quote currency as a string parseable to a positive number
+- `high` **Required** highest price of the asset in the quote currency as a string parseable to a positive number
+- `low` **Required** lowest price of the asset in the quote currency as a string parseable to a positive number
+- `volume` **Required** volume of the asset in the base currency as a string parseable to a positive number
+- `vwap` volume weighted average price of the asset in the quote currency as a string parseable to a positive number
 
 ## `/trades-by-timestamp` - Historical Executed Trades Paged by Timestamp - **Discouraged**
 

--- a/doc/cryptocurrency-api-exchange-integration.md
+++ b/doc/cryptocurrency-api-exchange-integration.md
@@ -229,7 +229,6 @@ JSON array of OHLCV Candles for the given market and interval. If daily candles 
 - `high` **Required** highest price of the asset in the quote currency as a string parseable to a positive number
 - `low` **Required** lowest price of the asset in the quote currency as a string parseable to a positive number
 - `volume` **Required** volume of the asset in the base currency as a string parseable to a positive number
-- `vwap` volume weighted average price of the asset in the quote currency as a string parseable to a positive number
 
 ## `/trades-by-timestamp` - Historical Executed Trades Paged by Timestamp - **Discouraged**
 

--- a/doc/cryptocurrency-api-exchange-integration.md
+++ b/doc/cryptocurrency-api-exchange-integration.md
@@ -206,7 +206,7 @@ Bids **must be sorted in descending order** and asks **must be sorted in ascendi
 
 When returning orders, perform as little aggregation as possible (ideally none) and include as many orders as possible (ideally all).
 
-## `/candles` - Candles - **Optional**
+## `/candles` - Candles - **Discouraged**
 
 **If you implement `/trades` you do not need to implement `/candles`.**
 
@@ -221,9 +221,9 @@ The `/candles` endpoint returns open, high, low, close, and volume data for a gi
 
 ### Response
 
-JSON array of OHLCV Candles for the given market and interval. If daily candles are available, as many as possible should be returned (preferably to inception). Otherwise, a sliding 24 hour, 1 hour, or 1 minute ticker should be returned as the only "candle". Candles have the following properties:
+JSON array of OHLCV Candles for the given market and interval. If daily candles are available, as many as possible should be returned (preferably to inception). Otherwise, a fixed 24 hour, 1 hour, or 1 minute ticker should be returned as the only "candle". Timestamps should be aligned to candle size. IE: Midnight UTC (`2018-01-01T:00:00:00.000Z`) for `1d`, to the hour (`2018-01-01T03:00:00.000Z`) for `1h`, and to the minute (`2018-01-01T03:03:00.000Z`) for `1m`. Candles have the following properties:
 
-- `timestamp` **Required** timestamp of the candle in RFC3339
+- `timestamp` **Required** timestamp of the start of the candle in RFC3339 aligned to candle size in UTC
 - `close` **Required** close price of the asset in the quote currency as a string parseable to a positive number
 - `open` **Required** open price of the asset in the quote currency as a string parseable to a positive number
 - `high` **Required** highest price of the asset in the quote currency as a string parseable to a positive number

--- a/example/index.js
+++ b/example/index.js
@@ -38,43 +38,45 @@ function info (_, res) {
 }
 
 function markets (_, res) {
-  res.send([{
-    id: 'btc-usd',
-    base: 'BTC',
-    quote: 'USD'
-  }])
+  res.send([
+    {
+      id: 'btc-usd',
+      base: 'BTC',
+      quote: 'USD'
+    }
+  ])
 }
 
 const allTrades = [
   {
-    'id': '1',
-    'timestamp': '2006-01-02T15:04:05.999+07:00',
-    'price': '100.00',
-    'amount': '10.00',
-    'order': '1',
-    'type': 'market',
-    'side': 'buy',
-    'raw': [1, 1136214245, 100.00, 10.00, '1', 'm', 'b']
+    id: '1',
+    timestamp: '2006-01-02T15:04:05.999+07:00',
+    price: '100.00',
+    amount: '10.00',
+    order: '1',
+    type: 'market',
+    side: 'buy',
+    raw: [1, 1136214245, 100.0, 10.0, '1', 'm', 'b']
   },
   {
-    'id': '2',
-    'timestamp': '2006-01-02T15:14:05.999+07:00',
-    'price': '98.00',
-    'amount': '1.00',
-    'order': '3',
-    'type': 'market',
-    'side': 'sell',
-    'raw': [2, 1136214255, 98.00, 1.00, '3', 'm', 's']
+    id: '2',
+    timestamp: '2006-01-02T15:14:05.999+07:00',
+    price: '98.00',
+    amount: '1.00',
+    order: '3',
+    type: 'market',
+    side: 'sell',
+    raw: [2, 1136214255, 98.0, 1.0, '3', 'm', 's']
   },
   {
-    'id': '3',
-    'timestamp': '2006-01-02T15:24:05.999+07:00',
-    'price': '101.37',
-    'amount': '3.50',
-    'order': '5',
-    'type': 'limit',
-    'side': 'buy',
-    'raw': [3, 1136214265, 101.37, 3.50, '5', 'l', 'b']
+    id: '3',
+    timestamp: '2006-01-02T15:24:05.999+07:00',
+    price: '101.37',
+    amount: '3.50',
+    order: '5',
+    type: 'limit',
+    side: 'buy',
+    raw: [3, 1136214265, 101.37, 3.5, '5', 'l', 'b']
   }
 ]
 
@@ -87,7 +89,7 @@ function trades (req, res) {
   if (isNaN(since)) {
     since = 0
   }
-  res.send(allTrades.filter((t) => parseInt(t.id) > since))
+  res.send(allTrades.filter(t => parseInt(t.id) > since))
 }
 
 function tradesByTimestamp (req, res) {
@@ -101,7 +103,7 @@ function tradesByTimestamp (req, res) {
   } else {
     since = new Date(0)
   }
-  res.send(allTrades.filter((t) => (new Date(t.timestamp)).getTime() > since.getTime()))
+  res.send(allTrades.filter(t => new Date(t.timestamp).getTime() > since.getTime()))
 }
 
 function ordersSnapshot (req, res) {
@@ -110,14 +112,8 @@ function ordersSnapshot (req, res) {
     return
   }
   res.send({
-    bids: [
-      [5000.00, 1.00],
-      [4900.00, 10.00]
-    ],
-    asks: [
-      [5100.00, 5.00],
-      [5150.00, 10.00]
-    ],
+    bids: [[5000.0, 1.0], [4900.0, 10.0]],
+    asks: [[5100.0, 5.0], [5150.0, 10.0]],
     timestamp: new Date()
   })
 }
@@ -127,9 +123,20 @@ function candles (req, res) {
     res.status(404).send({ error: 'unknown market' })
     return
   }
-  res.send([
+
+  if (!['1d', '1h', '1m'].includes(req.query.interval)) {
+    res.status(404).send({ error: 'unknown interval' })
+    return
+  }
+
+  const timestamps = {
+    '1d': ['2018-12-02T00:00:00.000Z', '2018-12-03T00:00:00.000Z', '2018-12-04T00:00:00.000Z'],
+    '1h': ['2018-12-01T01:00:00.000Z', '2018-12-01T02:00:00.000Z', '2018-12-01T03:00:00.000Z'],
+    '1m': ['2018-12-01T01:01:00.000Z', '2018-12-01T01:01:00.000Z', '2018-12-01T01:01:00.000Z']
+  }
+
+  const data = [
     {
-      timestamp: '2018-12-02T00:00:00.000Z',
       open: '4002.8',
       high: '4119.98',
       low: '3741.95',
@@ -137,7 +144,6 @@ function candles (req, res) {
       volume: '19040.84'
     },
     {
-      timestamp: '2018-12-03T00:00:00.000Z',
       open: '4102.8',
       high: '4119.98',
       low: '3741.95',
@@ -145,14 +151,20 @@ function candles (req, res) {
       volume: '17040.84'
     },
     {
-      timestamp: '2018-12-04T00:00:00.000Z',
       open: '3833.47',
       high: '4035.1',
       low: '3732.43',
       close: '3909.3',
       volume: '13642.42'
     }
-  ])
+  ]
+
+  res.send(
+    data.map((d, i) => {
+      d.timestamp = timestamps[req.query.interval][i]
+      return d
+    })
+  )
 }
 
 if (require.main === module) {

--- a/example/index.js
+++ b/example/index.js
@@ -9,6 +9,7 @@ function Server () {
   app.get('/trades', trades)
   app.get('/trades-by-timestamp', tradesByTimestamp)
   app.get('/orders/snapshot', ordersSnapshot)
+  app.get('/candles', candles)
 
   return app
 }
@@ -31,7 +32,7 @@ function info (_, res) {
       orders: false,
       ordersSocket: false,
       ordersSnapshot: true,
-      candles: false
+      candles: ['1d', '1h']
     }
   })
 }
@@ -119,6 +120,39 @@ function ordersSnapshot (req, res) {
     ],
     timestamp: new Date()
   })
+}
+
+function candles (req, res) {
+  if (req.query.market !== 'btc-usd') {
+    res.status(404).send({ error: 'unknown market' })
+    return
+  }
+  res.send([
+    {
+      timestamp: '2018-12-02T00:00:00.000Z',
+      open: '4002.8',
+      high: '4119.98',
+      low: '3741.95',
+      close: '4102.8',
+      volume: '19040.84'
+    },
+    {
+      timestamp: '2018-12-03T00:00:00.000Z',
+      open: '4102.8',
+      high: '4119.98',
+      low: '3741.95',
+      close: '3833.47',
+      volume: '17040.84'
+    },
+    {
+      timestamp: '2018-12-04T00:00:00.000Z',
+      open: '3833.47',
+      high: '4035.1',
+      low: '3732.43',
+      close: '3909.3',
+      volume: '13642.42'
+    }
+  ])
 }
 
 if (require.main === module) {

--- a/lib/audit/au.js
+++ b/lib/audit/au.js
@@ -121,7 +121,14 @@ const au = {
   assertPropertyInSet: function (o, p, s, opts = {}) {
     opts = Object.assign({ required: true }, opts)
     if (au.assertProperty(o, p, opts)) {
-      au.assert(s.indexOf(o[p]) > -1, `Expected '${p}' to be one of '${JSON.stringify(s)}': ${JSON.stringify(o)}`)
+      if (o[p] instanceof Array) {
+        au.assert(
+          o[p].every(val => s.includes(val)),
+          `Expected ${o[p]} to only contain values from ${s}: ${JSON.stringify(o)}`
+        )
+      } else {
+        au.assert(s.indexOf(o[p]) > -1, `Expected '${p}' to be one of '${JSON.stringify(s)}': ${JSON.stringify(o)}`)
+      }
     }
   },
 

--- a/lib/audit/test/audit.js
+++ b/lib/audit/test/audit.js
@@ -1,3 +1,4 @@
+const moment = require('moment')
 const au = require('../au')
 
 module.exports = {
@@ -192,7 +193,64 @@ module.exports = {
           }
         }
 
-        au.assert(candles.length > 2, 'Expected more than two candles')
+        const c = JSON.parse(JSON.stringify(candles)) // deep clone
+        let t = candles.map(c => c.timestamp)
+        let tSorted = c.map(c => c.timestamp).sort()
+
+        au.assert(
+          JSON.stringify(t) === JSON.stringify(tSorted),
+          `Expected ${interval} candles to be sorted by timestamp ascending`
+        )
+
+        if (interval === '1d') {
+          au.assert(candles.length >= 7, 'Expected at least 7 1d candles')
+          au.assert(
+            new Date(candles[candles.length - 1].timestamp).getTime() ===
+              moment()
+                .utc()
+                .startOf('day')
+                .toDate()
+                .getTime(),
+            `Expected last 1d candle to be current day UTC: ${JSON.stringify(candles[candles.length - 1])}`
+          )
+          au.assert(
+            new Date(candles[candles.length - 2].timestamp).getTime() ===
+              moment()
+                .utc()
+                .subtract(1, 'day')
+                .startOf('day')
+                .toDate()
+                .getTime(),
+            'Expected next to last 1d candle to be previous day UTC'
+          )
+        }
+
+        if (interval === '1h') {
+          au.assert(candles.length >= 24, 'Expected at least 24 1h candles')
+          au.assert(
+            new Date(candles[candles.length - 1].timestamp).getTime() ===
+              moment()
+                .utc()
+                .startOf('hour')
+                .toDate()
+                .getTime(),
+            `Expected last 1h candle to be current hour UTC: ${JSON.stringify(candles[candles.length - 1])}`
+          )
+          au.assert(
+            new Date(candles[candles.length - 2].timestamp).getTime() ===
+              moment()
+                .utc()
+                .subtract(1, 'hour')
+                .startOf('hour')
+                .toDate()
+                .getTime(),
+            'Expected next to last 1h candle to be previous hour UTC'
+          )
+        }
+
+        if (interval === '1m') {
+          au.assert(candles.length >= 60, 'Expected at least 60 1m candles')
+        }
 
         candles.forEach(c => {
           au.assertTimestampProperty(c, 'timestamp')

--- a/lib/audit/test/audit.js
+++ b/lib/audit/test/audit.js
@@ -38,9 +38,9 @@ module.exports = {
     const data = await au.get('/markets')
 
     au.assert(data.length > 0, 'Expected at least one market')
-    data.forEach((m) => au.assertStringProperty(m, 'id'))
-    data.forEach((m) => au.assertStringProperty(m, 'base', { required: false }))
-    data.forEach((m) => au.assertStringProperty(m, 'quote', { required: false }))
+    data.forEach(m => au.assertStringProperty(m, 'id'))
+    data.forEach(m => au.assertStringProperty(m, 'base', { required: false }))
+    data.forEach(m => au.assertStringProperty(m, 'quote', { required: false }))
 
     const idCounts = data.reduce((memo, m) => {
       if (!memo[m.id]) {
@@ -49,7 +49,7 @@ module.exports = {
       memo[m.id]++
       return memo
     }, {})
-    Object.keys(idCounts).forEach((id) => {
+    Object.keys(idCounts).forEach(id => {
       au.assert(idCounts[id] === 1, `Duplicate market ID: ${id}`)
     })
   },
@@ -68,24 +68,26 @@ module.exports = {
 
     const trades = await au.get(`/trades?market=${encodeURIComponent(market.id)}`)
     au.assert(trades.length > 2, 'Expected more than two trades')
-    trades.forEach((t) => au.assertStringProperty(t, 'id'))
-    trades.forEach((t) => au.assertTimestampProperty(t, 'timestamp'))
-    trades.forEach((t) => au.assertNumericStringProperty(t, 'price'))
-    trades.forEach((t) => au.assertNumericStringProperty(t, 'amount'))
-    trades.forEach((t) => au.assertStringProperty(t, 'order', { required: false }))
-    trades.forEach((t) => au.assertPropertyInSet(t, 'type', ['market', 'limit', 'ask', 'bid'], { required: false }))
-    trades.forEach((t) => au.assertPropertyInSet(t, 'side', ['buy', 'sell'], { required: false }))
+    trades.forEach(t => au.assertStringProperty(t, 'id'))
+    trades.forEach(t => au.assertTimestampProperty(t, 'timestamp'))
+    trades.forEach(t => au.assertNumericStringProperty(t, 'price'))
+    trades.forEach(t => au.assertNumericStringProperty(t, 'amount'))
+    trades.forEach(t => au.assertStringProperty(t, 'order', { required: false }))
+    trades.forEach(t => au.assertPropertyInSet(t, 'type', ['market', 'limit', 'ask', 'bid'], { required: false }))
+    trades.forEach(t => au.assertPropertyInSet(t, 'side', ['buy', 'sell'], { required: false }))
 
     const since = trades[0].id
     const second = await au.get(`/trades?market=${encodeURIComponent(market.id)}&since=${since}`)
     au.assert(second.length > 0, `Trades with since=${since} didn't return any trades`)
     au.assert(
-      !second.find((t) => t.id === since),
+      !second.find(t => t.id === since),
       `Trades with since=${since} contained a trade with the same id as the since parameter. Only trades *after* the since id should be returned`
     )
     au.assert(
-      second.find((t) => t.id === trades[1].id),
-      `Trades with since=${since} didn't contain an overlap with the first page. Expected to see trade with id ${trades[1].id}`
+      second.find(t => t.id === trades[1].id),
+      `Trades with since=${since} didn't contain an overlap with the first page. Expected to see trade with id ${
+        trades[1].id
+      }`
     )
   },
 
@@ -103,24 +105,30 @@ module.exports = {
 
     const trades = await au.get(`/trades-by-timestamp?market=${encodeURIComponent(market.id)}`)
     au.assert(trades.length > 2, 'Expected more than two trades')
-    trades.forEach((t) => au.assertStringProperty(t, 'id'))
-    trades.forEach((t) => au.assertTimestampProperty(t, 'timestamp'))
-    trades.forEach((t) => au.assertNumericStringProperty(t, 'price'))
-    trades.forEach((t) => au.assertNumericStringProperty(t, 'amount'))
-    trades.forEach((t) => au.assertStringProperty(t, 'order', { required: false }))
-    trades.forEach((t) => au.assertPropertyInSet(t, 'type', ['market', 'limit', 'ask', 'bid'], { required: false }))
-    trades.forEach((t) => au.assertPropertyInSet(t, 'side', ['buy', 'sell'], { required: false }))
+    trades.forEach(t => au.assertStringProperty(t, 'id'))
+    trades.forEach(t => au.assertTimestampProperty(t, 'timestamp'))
+    trades.forEach(t => au.assertNumericStringProperty(t, 'price'))
+    trades.forEach(t => au.assertNumericStringProperty(t, 'amount'))
+    trades.forEach(t => au.assertStringProperty(t, 'order', { required: false }))
+    trades.forEach(t => au.assertPropertyInSet(t, 'type', ['market', 'limit', 'ask', 'bid'], { required: false }))
+    trades.forEach(t => au.assertPropertyInSet(t, 'side', ['buy', 'sell'], { required: false }))
 
     const since = trades[0].timestamp
-    const second = await au.get(`/trades-by-timestamp?market=${encodeURIComponent(market.id)}&since=${encodeURIComponent(since)}`)
+    const second = await au.get(
+      `/trades-by-timestamp?market=${encodeURIComponent(market.id)}&since=${encodeURIComponent(since)}`
+    )
     au.assert(second.length > 0, `Trades with since=${since} didn't return any trades`)
     au.assert(
-      !second.find((t) => t.id === trades[0].id),
-      `Trades with since=${trades[0].id} contained a trade with the same id as the since parameter. Only trades *after* the since id should be returned`
+      !second.find(t => t.id === trades[0].id),
+      `Trades with since=${
+        trades[0].id
+      } contained a trade with the same id as the since parameter. Only trades *after* the since id should be returned`
     )
     au.assert(
-      second.find((t) => t.id === trades[1].id),
-      `Trades with since=${trades[0].id} didn't contain an overlap with the first page. Expected to see trade with id ${trades[1].id}`
+      second.find(t => t.id === trades[1].id),
+      `Trades with since=${trades[0].id} didn't contain an overlap with the first page. Expected to see trade with id ${
+        trades[1].id
+      }`
     )
   },
 
@@ -141,15 +149,15 @@ module.exports = {
     au.assertArrayProperty(orderBook, 'bids')
     au.assertArrayProperty(orderBook, 'asks')
 
-    const bidPrices = orderBook.bids.map((b) => b[0])
-    const bidPricesSorted = orderBook.bids.map((b) => b[0]).sort((a, b) => b - a)
+    const bidPrices = orderBook.bids.map(b => b[0])
+    const bidPricesSorted = orderBook.bids.map(b => b[0]).sort((a, b) => b - a)
     au.assert(
       JSON.stringify(bidPrices) === JSON.stringify(bidPricesSorted),
       'Expected bids to be sorted by price descending'
     )
 
-    const askPrices = orderBook.asks.map((b) => b[0])
-    const askPricesSorted = orderBook.asks.map((b) => b[0]).sort((a, b) => a - b)
+    const askPrices = orderBook.asks.map(b => b[0])
+    const askPricesSorted = orderBook.asks.map(b => b[0]).sort((a, b) => a - b)
     au.assert(
       JSON.stringify(askPrices) === JSON.stringify(askPricesSorted),
       'Expected asks to be sorted by price ascending'
@@ -168,14 +176,50 @@ module.exports = {
     }
 
     const market = markets[0]
-    const candles = await au.get(`/candles?market=${encodeURIComponent(market.id)}&interval=1d`)
+    const intervals = ['1d', '1h', '1m']
 
-    au.assert(candles.length > 2, 'Expected more than two candles')
-    candles.forEach(c => au.assertTimestampProperty(c, 'timestamp'))
-    candles.forEach(c => au.assertNumericStringProperty(c, 'open'))
-    candles.forEach(c => au.assertNumericStringProperty(c, 'high'))
-    candles.forEach(c => au.assertNumericStringProperty(c, 'low'))
-    candles.forEach(c => au.assertNumericStringProperty(c, 'close'))
-    candles.forEach(c => au.assertNumericStringProperty(c, 'volume'))
+    await Promise.all(
+      intervals.map(async interval => {
+        let candles
+
+        try {
+          candles = await au.get(`/candles?market=${encodeURIComponent(market.id)}&interval=${interval}`)
+        } catch (e) {
+          if (interval === '1d') {
+            au.assert(false, 'Expected to find candles endpoint for interval `1d`')
+          } else {
+            return // other candles endpoints are optional
+          }
+        }
+
+        au.assert(candles.length > 2, 'Expected more than two candles')
+
+        candles.forEach(c => {
+          au.assertTimestampProperty(c, 'timestamp')
+
+          let date = new Date(c.timestamp)
+
+          if (interval === '1d') {
+            au.assert(date.getUTCHours() === 0, 'Expected timestamp hours to aligned to candle size in UTC')
+          }
+
+          if (['1d', '1h'].includes(interval)) {
+            au.assert(date.getUTCMinutes() === 0, 'Expected timestamp minutes to aligned to candle size in UTC')
+          }
+
+          if (['1d', '1h', '1m'].includes(interval)) {
+            au.assert(date.getUTCSeconds() === 0, 'Expected timestamp seconds to aligned to candle size in UTC')
+          }
+
+          au.assert(date.getUTCMilliseconds() === 0, 'Expected timestamp milliseconds to align to candle size in UTC')
+        })
+
+        candles.forEach(c => au.assertNumericStringProperty(c, 'open'))
+        candles.forEach(c => au.assertNumericStringProperty(c, 'high'))
+        candles.forEach(c => au.assertNumericStringProperty(c, 'low'))
+        candles.forEach(c => au.assertNumericStringProperty(c, 'close'))
+        candles.forEach(c => au.assertNumericStringProperty(c, 'volume'))
+      })
+    )
   }
 }

--- a/lib/audit/test/audit.js
+++ b/lib/audit/test/audit.js
@@ -211,7 +211,7 @@ module.exports = {
                 .startOf('day')
                 .toDate()
                 .getTime(),
-            `Expected last 1d candle to be current day UTC: ${JSON.stringify(candles[candles.length - 1])}`
+            `Expected last 1d candle to be current day UTC: ${candles[candles.length - 1].timestamp}`
           )
           au.assert(
             new Date(candles[candles.length - 2].timestamp).getTime() ===
@@ -221,7 +221,7 @@ module.exports = {
                 .startOf('day')
                 .toDate()
                 .getTime(),
-            'Expected next to last 1d candle to be previous day UTC'
+            `Expected next to last 1d candle to be previous day UTC: ${candles[candles.length - 2].timestamp}`
           )
         }
 
@@ -234,7 +234,7 @@ module.exports = {
                 .startOf('hour')
                 .toDate()
                 .getTime(),
-            `Expected last 1h candle to be current hour UTC: ${JSON.stringify(candles[candles.length - 1])}`
+            `Expected last 1h candle to be current hour UTC: ${candles[candles.length - 1].timestamp}`
           )
           au.assert(
             new Date(candles[candles.length - 2].timestamp).getTime() ===
@@ -244,7 +244,7 @@ module.exports = {
                 .startOf('hour')
                 .toDate()
                 .getTime(),
-            'Expected next to last 1h candle to be previous hour UTC'
+            `Expected next to last 1h candle to be previous hour UTC: ${candles[candles.length - 2].timestamp}`
           )
         }
 

--- a/lib/audit/test/audit.js
+++ b/lib/audit/test/audit.js
@@ -26,7 +26,7 @@ module.exports = {
       au.assertBooleanProperty(capability, 'orders', { required: false })
       au.assertBooleanProperty(capability, 'ordersSocket', { required: false })
       au.assertBooleanProperty(capability, 'ordersSnapshot', { required: false })
-      au.assertBooleanProperty(capability, 'candles', { required: false })
+      au.assertPropertyInSet(capability, 'candles', ['1d', '1h', '1m'], { required: false })
     }
   },
 
@@ -154,5 +154,28 @@ module.exports = {
       JSON.stringify(askPrices) === JSON.stringify(askPricesSorted),
       'Expected asks to be sorted by price ascending'
     )
+  },
+
+  candles: async () => {
+    if (!this.info.capability || !this.info.capability.candles) {
+      return
+    }
+
+    const markets = await au.get('/markets')
+    if (markets.length === 0) {
+      // If there are no markets, pass, since markets spec will fail
+      return
+    }
+
+    const market = markets[0]
+    const candles = await au.get(`/candles?market=${encodeURIComponent(market.id)}&interval=1d`)
+
+    au.assert(candles.length > 2, 'Expected more than two candles')
+    candles.forEach(c => au.assertTimestampProperty(c, 'timestamp'))
+    candles.forEach(c => au.assertNumericStringProperty(c, 'open'))
+    candles.forEach(c => au.assertNumericStringProperty(c, 'high'))
+    candles.forEach(c => au.assertNumericStringProperty(c, 'low'))
+    candles.forEach(c => au.assertNumericStringProperty(c, 'close'))
+    candles.forEach(c => au.assertNumericStringProperty(c, 'volume'))
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "axios": "^0.18.0",
+    "moment": "^2.22.2",
     "teenytest": "^5.1.1",
     "teenytest-promise": "^1.0.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -930,6 +930,11 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
+moment@^2.22.2:
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
+  integrity sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
Adds specification for the OHLCV `/candles` endpoint to allow Nomics to get ongoing and some historical market price data. The `/candles` endpoint is still discouraged in favor of implementing a proper `/trades` endpoint when possible.