### PR TITLE
Fix issue with nested promises on candles auditor

### DIFF
--- a/lib/audit/test/audit.js
+++ b/lib/audit/test/audit.js
@@ -182,95 +182,93 @@ module.exports = {
     const market = markets[0]
     const intervals = ['1d', '1h', '1m']
 
-    await Promise.all(
-      intervals.map(async interval => {
-        let candles
+    for (const interval of intervals) {
+      let candles
 
-        try {
-          candles = await au.get(`/candles?market=${encodeURIComponent(market.id)}&interval=${interval}`)
-        } catch (e) {
-          if (interval === '1d') {
-            au.assert(false, 'Expected to find candles endpoint for interval `1d`')
-          } else {
-            return // other candles endpoints are optional
-          }
+      try {
+        candles = await au.get(`/candles?market=${encodeURIComponent(market.id)}&interval=${interval}`)
+      } catch (e) {
+        if (interval === '1d') {
+          au.assert(false, 'Expected to find candles endpoint for interval `1d`')
+        } else {
+          return // other candles endpoints are optional
         }
+      }
 
-        const c = JSON.parse(JSON.stringify(candles)) // deep clone
-        let t = candles.map(c => c.timestamp)
-        let tSorted = c.map(c => c.timestamp).sort()
+      const c = JSON.parse(JSON.stringify(candles)) // deep clone
+      let t = candles.map(c => c.timestamp)
+      let tSorted = c.map(c => c.timestamp).sort()
 
+      au.assert(
+        JSON.stringify(t) === JSON.stringify(tSorted),
+        `Expected ${interval} candles to be sorted by timestamp ascending`
+      )
+
+      if (interval === '1d') {
+        au.assert(candles.length >= 7, 'Expected at least 7 1d candles')
         au.assert(
-          JSON.stringify(t) === JSON.stringify(tSorted),
-          `Expected ${interval} candles to be sorted by timestamp ascending`
+          new Date(candles[candles.length - 1].timestamp).getTime() > new Date().getTime() - 2 * DAY,
+          'Expected last 1d candle to be within the last 48 hours'
         )
+      }
+
+      if (interval === '1h') {
+        au.assert(candles.length >= 24, 'Expected at least 24 1h candles')
+        au.assert(
+          new Date(candles[candles.length - 1].timestamp).getTime() > new Date().getTime() - 2 * HOUR,
+          'Expected last 1h candle to be within the last 2 hours'
+        )
+      }
+
+      if (interval === '1m') {
+        au.assert(candles.length >= 60, 'Expected at least 60 1m candles')
+        au.assert(
+          new Date(candles[candles.length - 1].timestamp).getTime() > new Date().getTime() - 10 * MINUTE,
+          'Expected last 1m candle to be within the last 10 minutes'
+        )
+      }
+
+      candles.forEach(c => {
+        au.assertTimestampProperty(c, 'timestamp')
+
+        let date = new Date(c.timestamp)
 
         if (interval === '1d') {
-          au.assert(candles.length >= 7, 'Expected at least 7 1d candles')
-          au.assert(
-            new Date(candles[candles.length - 1].timestamp).getTime() > new Date().getTime() - 2 * DAY,
-            'Expected last 1d candle to be within the last 48 hours'
-          )
+          au.assert(date.getTime() % DAY === 0, 'Expected timestamp to aligned to day candle size in UTC')
         }
 
         if (interval === '1h') {
-          au.assert(candles.length >= 24, 'Expected at least 24 1h candles')
-          au.assert(
-            new Date(candles[candles.length - 1].timestamp).getTime() > new Date().getTime() - 2 * HOUR,
-            'Expected last 1h candle to be within the last 2 hours'
-          )
+          au.assert(date.getTime() % HOUR === 0, 'Expected timestamp to aligned to hour candle size in UTC')
         }
 
-        if (interval === '1m') {
-          au.assert(candles.length >= 60, 'Expected at least 60 1m candles')
-          au.assert(
-            new Date(candles[candles.length - 1].timestamp).getTime() > new Date().getTime() - 10 * MINUTE,
-            'Expected last 1m candle to be within the last 10 minutes'
-          )
+        if (interval === '1d') {
+          au.assert(date.getTime() % MINUTE === 0, 'Expected timestamp to aligned to minute candle size in UTC')
         }
-
-        candles.forEach(c => {
-          au.assertTimestampProperty(c, 'timestamp')
-
-          let date = new Date(c.timestamp)
-
-          if (interval === '1d') {
-            au.assert(date.getTime() % DAY === 0, 'Expected timestamp to aligned to day candle size in UTC')
-          }
-
-          if (interval === '1h') {
-            au.assert(date.getTime() % HOUR === 0, 'Expected timestamp to aligned to hour candle size in UTC')
-          }
-
-          if (interval === '1d') {
-            au.assert(date.getTime() % MINUTE === 0, 'Expected timestamp to aligned to minute candle size in UTC')
-          }
-        })
-
-        candles.forEach(c => au.assertNumericStringProperty(c, 'open'))
-
-        candles.forEach(c => {
-          au.assertNumericStringProperty(c, 'high')
-          au.assert(parseFloat(c.high) >= parseFloat(c.open), 'Expected high to be greater than or equal to open')
-          au.assert(parseFloat(c.high) >= parseFloat(c.close), 'Expected high to be greater than or equal to close')
-          au.assert(parseFloat(c.high) >= parseFloat(c.low), 'Expected high to be greater than or equal to low')
-        })
-
-        candles.forEach(c => {
-          au.assertNumericStringProperty(c, 'low')
-          au.assert(parseFloat(c.low) > 0, 'Expected low to be greater than 0')
-          au.assert(parseFloat(c.low) <= parseFloat(c.open), 'Expected low to be less than or equal to open')
-          au.assert(parseFloat(c.low) <= parseFloat(c.close), 'Expected low to be less than or equal to close')
-          au.assert(parseFloat(c.low) <= parseFloat(c.high), 'Expected low to be less than or equal to high')
-        })
-
-        candles.forEach(c => au.assertNumericStringProperty(c, 'close'))
-
-        candles.forEach(c => {
-          au.assertNumericStringProperty(c, 'volume')
-          au.assert(parseFloat(c.volume) >= 0, 'Expected volume to be greater than or equal to 0')
-        })
       })
-    )
+
+      candles.forEach(c => au.assertNumericStringProperty(c, 'open'))
+
+      candles.forEach(c => {
+        au.assertNumericStringProperty(c, 'high')
+        au.assert(parseFloat(c.high) >= parseFloat(c.open), 'Expected high to be greater than or equal to open')
+        au.assert(parseFloat(c.high) >= parseFloat(c.close), 'Expected high to be greater than or equal to close')
+        au.assert(parseFloat(c.high) >= parseFloat(c.low), 'Expected high to be greater than or equal to low')
+      })
+
+      candles.forEach(c => {
+        au.assertNumericStringProperty(c, 'low')
+        au.assert(parseFloat(c.low) > 0, 'Expected low to be greater than 0')
+        au.assert(parseFloat(c.low) <= parseFloat(c.open), 'Expected low to be less than or equal to open')
+        au.assert(parseFloat(c.low) <= parseFloat(c.close), 'Expected low to be less than or equal to close')
+        au.assert(parseFloat(c.low) <= parseFloat(c.high), 'Expected low to be less than or equal to high')
+      })
+
+      candles.forEach(c => au.assertNumericStringProperty(c, 'close'))
+
+      candles.forEach(c => {
+        au.assertNumericStringProperty(c, 'volume')
+        au.assert(parseFloat(c.volume) >= 0, 'Expected volume to be greater than or equal to 0')
+      })
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nomics-platform",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Nomics Platform Toolkit",
   "keywords": [
     "cryptocurrency",


### PR DESCRIPTION
This was causing false negatives for candles audits when the wrong interval audit checks were being ran for another interval. IE: `1h` checks were running against `1d` candles and failing