### PR TITLE
Add specification for tickers

### DIFF
--- a/doc/cryptocurrency-api-exchange-integration.md
+++ b/doc/cryptocurrency-api-exchange-integration.md
@@ -240,7 +240,7 @@ Candles are expected to include a minimum number of records for a given interval
 
 **If you implement `/trades` you do not need to implement `/ticker`.**
 
-The `/ticker` endpoint returns high, low, and last prices and 24h volume data for a given market. It allows Nomics to get a current snapshot of a given market. Implementing this endpoint requires the attributes above in addition to a market symbol and timestamp. Optional attributes include open, bid, and ask prices.
+The `/ticker` endpoint returns high, low, last prices, and 24h volume data for a given market. It allows Nomics to get a current snapshot of a given market. Implementing this endpoint requires the attributes above in addition to a market symbol and timestamp. Optional attributes include open, bid, and ask prices.
 
 **We highly recommend implementing the `/trades` endpoint instead of the `/ticker` endpoint.** The `/ticker` endpoint should be used as a last resort if implementing `/trades` is not possible.
 
@@ -250,24 +250,18 @@ The `/ticker` endpoint returns high, low, and last prices and 24h volume data fo
 
 ### Response
 
-JSON object of the current ticker values for the given market. If daily candles are available, as many as possible should be returned (preferably to inception). Otherwise, candles should be returned fixed 24 hour, 1 hour, or 1 minute intervals. Timestamps should be aligned to candle size. IE: Midnight UTC (`2018-01-01T:00:00:00.000Z`) for `1d`, to the hour (`2018-01-01T03:00:00.000Z`) for `1h`, and to the minute (`2018-01-01T03:03:00.000Z`) for `1m`. Candles should be sorted by timestamp ascending. Candles have the following properties:
-
-- `ask` **Optional** open price of the asset in the quote currency as a string parseable to a positive number
-- `bid` **Optional** open price of the asset in the quote currency as a string parseable to a positive number
+JSON object of the current ticker values for the given market. Tickers have the following properties:
 
 - `high` **Required** highest price of the asset in the quote currency as a string parseable to a positive number
 - `low` **Required** lowest price of the asset in the quote currency as a string parseable to a positive number
 - `close` **Required** the current price of the asset in the quote currency as a string parseable to a positive number
 - `timestamp` **Required** timestamp of the current ticker values in RFC3339 in UTC
 - `volume` **Required** volume of the asset in the base currency as a string parseable to a positive number
+- `raw` **Required** the raw ticker values as a JSON object
+- `ask` **Optional** open price of the asset in the quote currency as a string parseable to a positive number
+- `bid` **Optional** open price of the asset in the quote currency as a string parseable to a positive number
 
-- `raw` **Required**
-
-Candles are expected to include a minimum number of records for a given interval and to include the "last candle" within the given timeframe:
-
-- `1d`: 7 candles with last candle occuring within a rolling 48 hours
-- `1h`: 24 candles with last candle occuring within a rolling 2 hours
-- `1m`: 60 candles with last candle occurring within a rolling 10 minutes
+Tickers are expected to include the most current data for a given market.
 
 ## `/trades-by-timestamp` - Historical Executed Trades Paged by Timestamp - **Discouraged**
 

--- a/doc/cryptocurrency-api-exchange-integration.md
+++ b/doc/cryptocurrency-api-exchange-integration.md
@@ -236,6 +236,39 @@ Candles are expected to include a minimum number of records for a given interval
 - `1h`: 24 candles with last candle occuring within a rolling 2 hours
 - `1m`: 60 candles with last candle occurring within a rolling 10 minutes
 
+## `/ticker` - Ticker - **Discouraged**
+
+**If you implement `/trades` you do not need to implement `/ticker`.**
+
+The `/ticker` endpoint returns high, low, and last prices and 24h volume data for a given market. It allows Nomics to get a current snapshot of a given market. Implementing this endpoint requires the attributes above in addition to a market symbol and timestamp. Optional attributes include open, bid, and ask prices.
+
+**We highly recommend implementing the `/trades` endpoint instead of the `/ticker` endpoint.** The `/ticker` endpoint should be used as a last resort if implementing `/trades` is not possible.
+
+### Parameters
+
+- `market` **Required** A market ID from the `/markets` endpoint.
+
+### Response
+
+JSON object of the current ticker values for the given market. If daily candles are available, as many as possible should be returned (preferably to inception). Otherwise, candles should be returned fixed 24 hour, 1 hour, or 1 minute intervals. Timestamps should be aligned to candle size. IE: Midnight UTC (`2018-01-01T:00:00:00.000Z`) for `1d`, to the hour (`2018-01-01T03:00:00.000Z`) for `1h`, and to the minute (`2018-01-01T03:03:00.000Z`) for `1m`. Candles should be sorted by timestamp ascending. Candles have the following properties:
+
+- `ask` **Optional** open price of the asset in the quote currency as a string parseable to a positive number
+- `bid` **Optional** open price of the asset in the quote currency as a string parseable to a positive number
+
+- `high` **Required** highest price of the asset in the quote currency as a string parseable to a positive number
+- `low` **Required** lowest price of the asset in the quote currency as a string parseable to a positive number
+- `close` **Required** the current price of the asset in the quote currency as a string parseable to a positive number
+- `timestamp` **Required** timestamp of the current ticker values in RFC3339 in UTC
+- `volume` **Required** volume of the asset in the base currency as a string parseable to a positive number
+
+- `raw` **Required**
+
+Candles are expected to include a minimum number of records for a given interval and to include the "last candle" within the given timeframe:
+
+- `1d`: 7 candles with last candle occuring within a rolling 48 hours
+- `1h`: 24 candles with last candle occuring within a rolling 2 hours
+- `1m`: 60 candles with last candle occurring within a rolling 10 minutes
+
 ## `/trades-by-timestamp` - Historical Executed Trades Paged by Timestamp - **Discouraged**
 
 The `/trades-by-timestamp` endpoint is nearly identical to the `/trades` endpoint. The core difference is that the `since` parameter is an RFC3339 timestamp instead of an ID. Otherwise, the parameters and response are the same.

--- a/example/index.js
+++ b/example/index.js
@@ -36,7 +36,7 @@ function info (_, res) {
       orders: false,
       ordersSocket: false,
       ordersSnapshot: true,
-      candles: ['1d', '1h']
+      candles: true
     }
   })
 }

--- a/lib/audit/test/audit.js
+++ b/lib/audit/test/audit.js
@@ -23,15 +23,26 @@ module.exports = {
     if (au.assertProperty(this.info, 'capability', { required: false })) {
       au.assertPropertyType(this.info, 'capability', 'object')
       const capability = this.info.capability
+      au.assertBooleanProperty(capability, 'candles', { required: false })
       au.assertBooleanProperty(capability, 'markets', { required: false })
+      au.assertBooleanProperty(capability, 'orders', { required: false })
+      au.assertBooleanProperty(capability, 'ordersSnapshot', { required: false })
+      au.assertBooleanProperty(capability, 'ordersSocket', { required: false })
+      au.assertBooleanProperty(capability, 'ticker', { required: false })
       au.assertBooleanProperty(capability, 'trades', { required: false })
       au.assertBooleanProperty(capability, 'tradesByTimestamp', { required: false })
       au.assertBooleanProperty(capability, 'tradesSocket', { required: false })
-      au.assertBooleanProperty(capability, 'orders', { required: false })
-      au.assertBooleanProperty(capability, 'ordersSocket', { required: false })
-      au.assertBooleanProperty(capability, 'ordersSnapshot', { required: false })
-      au.assertPropertyInSet(capability, 'candles', ['1d', '1h', '1m'], { required: false })
     }
+
+    au.assert(
+      this.info.capability.trades ||
+        this.info.capability.tradesByTimestamp ||
+        this.info.capability.orders ||
+        this.info.capability.ordersSnapshot ||
+        this.info.capability.ticker ||
+        this.info.capability.candles,
+      'Expected at least one data capability of trades, candles, orders, or ticker'
+    )
   },
 
   markets: async () => {

--- a/lib/audit/test/audit.js
+++ b/lib/audit/test/audit.js
@@ -270,5 +270,40 @@ module.exports = {
         au.assert(parseFloat(c.volume) >= 0, 'Expected volume to be greater than or equal to 0')
       })
     }
+  },
+
+  ticker: async () => {
+    if (!this.info.capability || !this.info.capability.ticker) {
+      return
+    }
+
+    const markets = await au.get('/markets')
+    if (markets.length === 0) {
+      // If there are no markets, pass, since markets spec will fail
+      return
+    }
+
+    const market = markets[0]
+    const ticker = await au.get(`/ticker?market=${encodeURIComponent(market.id)}`)
+
+    au.assert(ticker !== null, `Expected a ticker response for market ${market.id}`)
+
+    au.assertNumericStringProperty(ticker, 'ask', { required: false })
+    au.assertNumericStringProperty(ticker, 'bid', { required: false })
+    au.assertNumericStringProperty(ticker, 'close', { required: true })
+    au.assertNumericStringProperty(ticker, 'high', { required: true })
+    au.assertNumericStringProperty(ticker, 'low', { required: true })
+    au.assertProperty(ticker, 'raw', { required: true })
+    au.assertTimestampProperty(ticker, 'timestamp', { required: true })
+
+    if (
+      au.assertNumericStringProperty(ticker, 'bid', { required: false }) &&
+      au.assertNumericStringProperty(ticker, 'ask', { required: false })
+    ) {
+      au.assert(Number(ticker.bid) < Number(ticker.ask), 'Expected ask to be greater than bid')
+    }
+    au.assert(Number(ticker.high) > Number(ticker.low), 'Expected high to be higher than low')
+    au.assert(Number(ticker.close) <= Number(ticker.high), 'Expected close to be less than or equal to high')
+    au.assert(Number(ticker.close) >= Number(ticker.low), 'Expected close to be greater than or equal to low')
   }
 }

--- a/lib/audit/test/audit.js
+++ b/lib/audit/test/audit.js
@@ -288,6 +288,11 @@ module.exports = {
       return
     }
 
+    au.assert(
+      this.info.capability.ticker && this.info.capability.markets,
+      'Expect markets capability if ticker capability is avaialable'
+    )
+
     const markets = await au.get('/markets')
     if (markets.length === 0) {
       // If there are no markets, pass, since markets spec will fail

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nomics-platform",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "description": "Nomics Platform Toolkit",
   "keywords": [
     "cryptocurrency",


### PR DESCRIPTION
This creates a specification to allow ingestion of market tickers from exchange integrations. Tickers should be provided for a single market at a time (via the `market` parameter). Implementing the ticker integration is **discouraged** in favor of trades.