### PR TITLE
Update ticker auditor

### DIFF
--- a/lib/audit/test/audit.js
+++ b/lib/audit/test/audit.js
@@ -295,48 +295,59 @@ module.exports = {
       return
     }
 
-    for (let i = 0; i < markets.length; i++) {
-      const market = markets[i]
-      const ticker = await au.get(`/ticker?market=${encodeURIComponent(market.id)}`)
+    // iterate through all markets and pass ticker audit at first successful response
+    // otherwise fail ticker audit
+    let success = false
+    for (let i = 0; i < markets.length && !success; i++) {
+      try {
+        const market = markets[i]
+        const ticker = await au.get(`/ticker?market=${encodeURIComponent(market.id)}`)
 
-      au.assert(ticker !== null, `Expected a ticker response for market ${market.id}`)
+        au.assert(ticker !== null, `Expected a ticker response for market ${market.id}`)
 
-      au.assertNumericStringProperty(ticker, 'close', { required: true })
-      au.assertNumericStringProperty(ticker, 'high', { required: true })
-      au.assertNumericStringProperty(ticker, 'low', { required: true })
-      au.assertProperty(ticker, 'raw', { required: true })
-      au.assertTimestampProperty(ticker, 'timestamp', { required: true })
+        au.assertNumericStringProperty(ticker, 'close', { required: true })
+        au.assertNumericStringProperty(ticker, 'high', { required: true })
+        au.assertNumericStringProperty(ticker, 'low', { required: true })
+        au.assertProperty(ticker, 'raw', { required: true })
+        au.assertTimestampProperty(ticker, 'timestamp', { required: true })
 
-      if (ticker.ask && ticker.bid) {
+        if (ticker.ask && ticker.bid) {
+          au.assert(
+            Number(ticker.bid) < Number(ticker.ask),
+            `Expected ask (${ticker.ask}) to be greater than bid (${ticker.bid})`
+          )
+        }
+        if (ticker.ask) {
+          au.assertNumericStringProperty(ticker, 'ask', { required: false })
+          au.assert(Number(ticker.ask) > 0, 'Expected ask to be greater than zero')
+        }
+        if (ticker.bid) {
+          au.assertNumericStringProperty(ticker, 'bid', { required: false })
+          au.assert(Number(ticker.bid) > 0, 'Expected bid to be greater than zero')
+        }
+
+        au.assert(Number(ticker.close) > 0, `Expected close (${ticker.close}) to be greater than zero`)
+        au.assert(Number(ticker.high) > 0, `Expected high (${ticker.high}) to be greater than zero`)
+        au.assert(Number(ticker.low) > 0, `Expected low (${ticker.low}) to be greater than zero`)
         au.assert(
-          Number(ticker.bid) < Number(ticker.ask),
-          `Expected ask (${ticker.ask}) to be greater than bid (${ticker.bid})`
+          Number(ticker.high) > Number(ticker.low),
+          `Expected high (${ticker.high}) to be higher than low (${ticker.low})`
         )
-      }
-      if (ticker.ask) {
-        au.assertNumericStringProperty(ticker, 'ask', { required: false })
-        au.assert(Number(ticker.ask) > 0, 'Expected ask to be greater than zero')
-      }
-      if (ticker.bid) {
-        au.assertNumericStringProperty(ticker, 'bid', { required: false })
-        au.assert(Number(ticker.bid) > 0, 'Expected bid to be greater than zero')
-      }
+        au.assert(
+          Number(ticker.close) <= Number(ticker.high),
+          `Expected close (${ticker.close}) to be less than or equal to high (${ticker.high})`
+        )
+        au.assert(
+          Number(ticker.close) >= Number(ticker.low),
+          `Expected close (${ticker.close}) to be greater than or equal to low (${ticker.low})`
+        )
 
-      au.assert(Number(ticker.close) > 0, `Expected close (${ticker.close}) to be greater than zero`)
-      au.assert(Number(ticker.high) > 0, `Expected high (${ticker.high}) to be greater than zero`)
-      au.assert(Number(ticker.low) > 0, `Expected low (${ticker.low}) to be greater than zero`)
-      au.assert(
-        Number(ticker.high) > Number(ticker.low),
-        `Expected high (${ticker.high}) to be higher than low (${ticker.low})`
-      )
-      au.assert(
-        Number(ticker.close) <= Number(ticker.high),
-        `Expected close (${ticker.close}) to be less than or equal to high (${ticker.high})`
-      )
-      au.assert(
-        Number(ticker.close) >= Number(ticker.low),
-        `Expected close (${ticker.close}) to be greater than or equal to low (${ticker.low})`
-      )
+        success = true
+      } catch (err) {
+        if (i === markets.length - 1) {
+          throw err
+        }
+      }
     }
   }
 }

--- a/lib/audit/test/audit.js
+++ b/lib/audit/test/audit.js
@@ -295,27 +295,48 @@ module.exports = {
       return
     }
 
-    const market = markets[0]
-    const ticker = await au.get(`/ticker?market=${encodeURIComponent(market.id)}`)
+    for (let i = 0; i < markets.length; i++) {
+      const market = markets[i]
+      const ticker = await au.get(`/ticker?market=${encodeURIComponent(market.id)}`)
 
-    au.assert(ticker !== null, `Expected a ticker response for market ${market.id}`)
+      au.assert(ticker !== null, `Expected a ticker response for market ${market.id}`)
 
-    au.assertNumericStringProperty(ticker, 'ask', { required: false })
-    au.assertNumericStringProperty(ticker, 'bid', { required: false })
-    au.assertNumericStringProperty(ticker, 'close', { required: true })
-    au.assertNumericStringProperty(ticker, 'high', { required: true })
-    au.assertNumericStringProperty(ticker, 'low', { required: true })
-    au.assertProperty(ticker, 'raw', { required: true })
-    au.assertTimestampProperty(ticker, 'timestamp', { required: true })
+      au.assertNumericStringProperty(ticker, 'close', { required: true })
+      au.assertNumericStringProperty(ticker, 'high', { required: true })
+      au.assertNumericStringProperty(ticker, 'low', { required: true })
+      au.assertProperty(ticker, 'raw', { required: true })
+      au.assertTimestampProperty(ticker, 'timestamp', { required: true })
 
-    if (
-      au.assertNumericStringProperty(ticker, 'bid', { required: false }) &&
-      au.assertNumericStringProperty(ticker, 'ask', { required: false })
-    ) {
-      au.assert(Number(ticker.bid) < Number(ticker.ask), 'Expected ask to be greater than bid')
+      if (ticker.ask && ticker.bid) {
+        au.assert(
+          Number(ticker.bid) < Number(ticker.ask),
+          `Expected ask (${ticker.ask}) to be greater than bid (${ticker.bid})`
+        )
+      }
+      if (ticker.ask) {
+        au.assertNumericStringProperty(ticker, 'ask', { required: false })
+        au.assert(Number(ticker.ask) > 0, 'Expected ask to be greater than zero')
+      }
+      if (ticker.bid) {
+        au.assertNumericStringProperty(ticker, 'bid', { required: false })
+        au.assert(Number(ticker.bid) > 0, 'Expected bid to be greater than zero')
+      }
+
+      au.assert(Number(ticker.close) > 0, `Expected close (${ticker.close}) to be greater than zero`)
+      au.assert(Number(ticker.high) > 0, `Expected high (${ticker.high}) to be greater than zero`)
+      au.assert(Number(ticker.low) > 0, `Expected low (${ticker.low}) to be greater than zero`)
+      au.assert(
+        Number(ticker.high) > Number(ticker.low),
+        `Expected high (${ticker.high}) to be higher than low (${ticker.low})`
+      )
+      au.assert(
+        Number(ticker.close) <= Number(ticker.high),
+        `Expected close (${ticker.close}) to be less than or equal to high (${ticker.high})`
+      )
+      au.assert(
+        Number(ticker.close) >= Number(ticker.low),
+        `Expected close (${ticker.close}) to be greater than or equal to low (${ticker.low})`
+      )
     }
-    au.assert(Number(ticker.high) > Number(ticker.low), 'Expected high to be higher than low')
-    au.assert(Number(ticker.close) <= Number(ticker.high), 'Expected close to be less than or equal to high')
-    au.assert(Number(ticker.close) >= Number(ticker.low), 'Expected close to be greater than or equal to low')
   }
 }


### PR DESCRIPTION
This PR adds additional checks to ensure all required values are greater than `0`. Additionally, this relaxes the ticker auditor to pass if at least one ticker market returns valid data.