### PR TITLE
Add ability to relax info audits

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To audit your endpoint, install Node.js and run:
 npx nomics-platform audit https://path-to-your-api-root
 ```
 
-If data functionality needs to be audited prior to all metadata being available, you can used the `NOMICS_PLATFORM_RELAX`
+If data functionality needs to be audited prior to all metadata being available, you can use the `NOMICS_PLATFORM_RELAX`
 environment variable to temporarily relax requirements for description length, logo URL, and location.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ To audit your endpoint, install Node.js and run:
 npx nomics-platform audit https://path-to-your-api-root
 ```
 
+If data functionality needs to be audited prior to all metadata being available, you can used the `NOMICS_PLATFORM_RELAX`
+environment variable to temporarily relax requirements for description length, logo URL, and location.
+
+```bash
+NOMICS_PLATFORM_RELAX=1 npx nomics-platform audit https://path-to-your-api-root
+```
+
 ## Nomics Integration Specifications
 
-* [Cryptocurrency API Exchange Integration Specification](doc/cryptocurrency-api-exchange-integration.md)
+- [Cryptocurrency API Exchange Integration Specification](doc/cryptocurrency-api-exchange-integration.md)

--- a/lib/audit/test/audit.js
+++ b/lib/audit/test/audit.js
@@ -17,8 +17,14 @@ module.exports = {
   info: async () => {
     au.assertStringProperty(this.info, 'name')
     au.assertStringProperty(this.info, 'description', { required: true })
-    au.assertStringProperty(this.info, 'location', { required: true })
-    au.assertURLProperty(this.info, 'logo', { required: true, https: true })
+
+    if (!process.env.NOMICS_PLATFORM_RELAX) {
+      au.assert(this.info.description.length >= 1000, 'Expected description to be at least 1,000 characters')
+
+      au.assertStringProperty(this.info, 'location', { required: true })
+      au.assertURLProperty(this.info, 'logo', { required: true, https: true })
+    }
+
     au.assertURLProperty(this.info, 'website', { required: true })
     au.assertStringProperty(this.info, 'twitter', { required: false })
     if (au.assertProperty(this.info, 'capability', { required: false })) {
@@ -34,8 +40,6 @@ module.exports = {
       au.assertBooleanProperty(capability, 'tradesByTimestamp', { required: false })
       au.assertBooleanProperty(capability, 'tradesSocket', { required: false })
     }
-
-    au.assert(this.info.description.length >= 1000, 'Expected description to be at least 1,000 characters')
 
     au.assert(
       this.info.capability.trades ||


### PR DESCRIPTION
Add ability to relax info requirements to test data functionality before all info is available.