### PR TITLE
Update required endpoints; Remove unsupported endpoints

### DIFF
--- a/doc/cryptocurrency-api-exchange-integration.md
+++ b/doc/cryptocurrency-api-exchange-integration.md
@@ -136,7 +136,7 @@ Notes:
 - The number of trades returned is up to the exchange's implementation.
 - Returning an empty array signifies there are no newer trades than the given `since` ID.
 
-## `/trades-by-timestamp` - Historical Executed Trades Paged by Timestamp - **Required (Discouraged)\***
+## `/trades-by-timestamp` - Historical Executed Trades Paged by Timestamp - **Required (Discouraged)**
 
 **If you implement `/trades` you do not need to implement `/trades-by-timestamp`.**
 


### PR DESCRIPTION
This does the following:

 - Marks `/orders/snapshot` as required
 - Marks `/trades` and `/trades-by-timestamp` as required but mutually exclusive
 - Removes `/trades/socket`
 - Removes `/orders`
 - Removes `/orders/socket`