### PR TITLE
audit: always sort bid and ask prices as strings during orderSnapshot audit

### DIFF
--- a/lib/audit/test/audit.js
+++ b/lib/audit/test/audit.js
@@ -273,7 +273,10 @@ module.exports = {
           const bid0 = parseFloat(bid[0])
           const bid1 = parseFloat(bid[1])
 
-          au.assert(typeof bid0 === 'number' && !isNaN(bid0), 'Expect bid price to be of type number or numeric string')
+          au.assert(
+            typeof bid0 === 'number' && !isNaN(bid0),
+            'Expect bid price to be of type number or numeric string'
+          )
           au.assert(
             typeof bid1 === 'number' && !isNaN(bid1),
             'Expect bid amount to be of type number or numeric string'
@@ -284,22 +287,34 @@ module.exports = {
           const ask0 = parseFloat(ask[0])
           const ask1 = parseFloat(ask[1])
 
-          au.assert(typeof ask0 === 'number' && !isNaN(ask0), 'Expect ask price to be of type number or numeric string')
+          au.assert(
+            typeof ask0 === 'number' && !isNaN(ask0),
+            'Expect ask price to be of type number or numeric string'
+          )
           au.assert(
             typeof ask1 === 'number' && !isNaN(ask1),
             'Expect ask amount to be of type number or numeric string'
           )
         })
 
+        au.assert(
+          typeof orderBook.bids[0] === typeof orderBook.asks[0],
+          'Expect ask prices and bid prices to be of the same type'
+        );
+
         const bidPrices = orderBook.bids.map(b => b[0])
-        const bidPricesSorted = orderBook.bids.map(b => b[0]).sort((a, b) => b - a)
+        const bidPricesSorted = typeof orderBook.bids[0][0] === 'number'
+          ? orderBook.bids.map(b => b[0]).sort((a, b) => b - a)
+          : orderBook.bids.map(b => b[0]).sort((a, b) => b.localeCompare(a));
         au.assert(
           JSON.stringify(bidPrices) === JSON.stringify(bidPricesSorted),
           'Expected bids to be sorted by price descending'
         )
 
         const askPrices = orderBook.asks.map(b => b[0])
-        const askPricesSorted = orderBook.asks.map(b => b[0]).sort((a, b) => a - b)
+        const askPricesSorted = typeof orderBook.asks[0][0] === 'number'
+          ? orderBook.asks.map(b => b[0]).sort((a, b) => a - b)
+          : orderBook.asks.map(b => b[0]).sort((a, b) => a.localeCompare(b));
         au.assert(
           JSON.stringify(askPrices) === JSON.stringify(askPricesSorted),
           'Expected asks to be sorted by price ascending'


### PR DESCRIPTION
This fixes an issue with sorting the values when an adapter returns them as strings.