### PR TITLE
audit: mark tradesSnapshot audit successful after the first pass

### DIFF
--- a/lib/audit/test/audit.js
+++ b/lib/audit/test/audit.js
@@ -265,6 +265,8 @@ module.exports = {
         trades.forEach(t => au.assertStringProperty(t, 'order', { required: false }))
         trades.forEach(t => au.assertPropertyInSet(t, 'type', TRADE_TYPES, { required: false }))
         trades.forEach(t => au.assertPropertyInSet(t, 'side', ['buy', 'sell'], { required: false }))
+
+        success = true
       } catch (err) {
         console.log(`FAILED: URL ${uri || err.stack} failed with "${err.message}"`)
 


### PR DESCRIPTION
Without this change, most adapters time out on the tradesSnapshot audit.