### PR TITLE
loop through markets on candles

### DIFF
--- a/lib/audit/test/audit.js
+++ b/lib/audit/test/audit.js
@@ -410,107 +410,157 @@ module.exports = {
 
   candles: async () => {
     if (!this.info.capability || !this.info.capability.candles) {
-      return
+      return;
     }
 
-    const markets = await au.get('/markets')
+    const markets = await au.get("/markets");
     if (markets.length === 0) {
       // If there are no markets, pass, since markets spec will fail
       return
     }
 
-    const market = markets[0]
-    const intervals = ['1d', '1h', '1m']
+    const intervals = ["1d", "1h", "1m"];
+    let success = false
     let uri
 
-    try {
-      for (const interval of intervals) {
-        uri = `/candles?market=${encodeURIComponent(market.id)}&interval=${interval}`
+    // Try all markets until success/fail
+    // This is to compensate for currencies with low trade activity that fail due to less than expected # of candles for an interval
+    for (let i = 0; i < markets.length && !success; i++) {
+      uri = null
+      try {
+        const market = markets[i];
 
-        const candles = await au.get(uri)
+        for (const interval of intervals) {
+          uri = `/candles?market=${encodeURIComponent(
+            market.id
+          )}&interval=${interval}`;
 
-        const c = JSON.parse(JSON.stringify(candles)) // deep clone
-        let t = candles.map(c => c.timestamp)
-        let tSorted = c.map(c => c.timestamp).sort()
+          const candles = await au.get(uri);
 
-        au.assert(
-          JSON.stringify(t) === JSON.stringify(tSorted),
-          `Expected ${interval} candles to be sorted by timestamp ascending`
-        )
+          const c = JSON.parse(JSON.stringify(candles)); // deep clone
+          let t = candles.map(c => c.timestamp);
+          let tSorted = c.map(c => c.timestamp).sort();
 
-        if (interval === '1d') {
-          au.assert(candles.length >= 7, 'Expected at least 7 1d candles')
           au.assert(
-            new Date(candles[candles.length - 1].timestamp).getTime() > new Date().getTime() - 2 * DAY,
-            'Expected last 1d candle to be within the last 48 hours'
-          )
+            JSON.stringify(t) === JSON.stringify(tSorted),
+            `Expected ${interval} candles to be sorted by timestamp ascending`
+          );
+
+          if (interval === "1d") {
+            au.assert(candles.length >= 7, "Expected at least 7 1d candles");
+            au.assert(
+              new Date(candles[candles.length - 1].timestamp).getTime() >
+                new Date().getTime() - 2 * DAY,
+              "Expected last 1d candle to be within the last 48 hours"
+            );
+          }
+
+          if (interval === "1h") {
+            au.assert(candles.length >= 24, "Expected at least 24 1h candles");
+            au.assert(
+              new Date(candles[candles.length - 1].timestamp).getTime() >
+                new Date().getTime() - 2 * HOUR,
+              "Expected last 1h candle to be within the last 2 hours"
+            );
+          }
+
+          if (interval === "1m") {
+            au.assert(candles.length >= 60, "Expected at least 60 1m candles");
+            au.assert(
+              new Date(candles[candles.length - 1].timestamp).getTime() >
+                new Date().getTime() - 10 * MINUTE,
+              "Expected last 1m candle to be within the last 10 minutes"
+            );
+          }
+
+          candles.forEach(c => {
+            au.assertTimestampProperty(c, "timestamp");
+
+            let date = new Date(c.timestamp);
+
+            if (interval === "1d") {
+              au.assert(
+                date.getTime() % DAY === 0,
+                "Expected timestamp to aligned to day candle size in UTC"
+              );
+            }
+
+            if (interval === "1h") {
+              au.assert(
+                date.getTime() % HOUR === 0,
+                "Expected timestamp to aligned to hour candle size in UTC"
+              );
+            }
+
+            if (interval === "1d") {
+              au.assert(
+                date.getTime() % MINUTE === 0,
+                "Expected timestamp to aligned to minute candle size in UTC"
+              );
+            }
+          });
+
+          candles.forEach(c => {
+            au.assertNumericStringProperty(c, "open");
+
+            au.assertNumericStringProperty(c, "high");
+            au.assert(
+              parseFloat(c.high) >= parseFloat(c.open),
+              "Expected high to be greater than or equal to open"
+            );
+            au.assert(
+              parseFloat(c.high) >= parseFloat(c.close),
+              "Expected high to be greater than or equal to close"
+            );
+            au.assert(
+              parseFloat(c.high) >= parseFloat(c.low),
+              "Expected high to be greater than or equal to low"
+            );
+
+            au.assertNumericStringProperty(c, "low");
+            au.assert(parseFloat(c.low) > 0, "Expected low to be greater than 0");
+            au.assert(
+              parseFloat(c.low) <= parseFloat(c.open),
+              "Expected low to be less than or equal to open"
+            );
+            au.assert(
+              parseFloat(c.low) <= parseFloat(c.close),
+              "Expected low to be less than or equal to close"
+            );
+            au.assert(
+              parseFloat(c.low) <= parseFloat(c.high),
+              "Expected low to be less than or equal to high"
+            );
+
+            au.assertNumericStringProperty(c, "close");
+
+            if (c.volume) {
+              au.assertNumericStringProperty(c, "volume");
+              au.assertNumericStringProperty(c, "volume_quote", {
+                required: false
+              });
+              au.assert(
+                parseFloat(c.volume) >= 0,
+                "Expected volume to be greater than or equal to 0"
+              );
+            } else {
+              au.assertNumericStringProperty(c, "volume_quote");
+              au.assertNumericStringProperty(c, "volume", { required: false });
+              au.assert(
+                parseFloat(c.volume_quote) >= 0,
+                "Expected volume to be greater than or equal to 0"
+              );
+            }
+          });
         }
+        success = true;
+      } catch (err) {
+        console.log(`FAILED: URL ${uri || err.stack} failed with "${err.message}"`);
 
-        if (interval === '1h') {
-          au.assert(candles.length >= 24, 'Expected at least 24 1h candles')
-          au.assert(
-            new Date(candles[candles.length - 1].timestamp).getTime() > new Date().getTime() - 2 * HOUR,
-            'Expected last 1h candle to be within the last 2 hours'
-          )
+        if (i === markets.length - 1) {
+          throw err;
         }
-
-        if (interval === '1m') {
-          au.assert(candles.length >= 60, 'Expected at least 60 1m candles')
-          au.assert(
-            new Date(candles[candles.length - 1].timestamp).getTime() > new Date().getTime() - 10 * MINUTE,
-            'Expected last 1m candle to be within the last 10 minutes'
-          )
-        }
-
-        candles.forEach(c => {
-          au.assertTimestampProperty(c, 'timestamp')
-
-          let date = new Date(c.timestamp)
-
-          if (interval === '1d') {
-            au.assert(date.getTime() % DAY === 0, 'Expected timestamp to aligned to day candle size in UTC')
-          }
-
-          if (interval === '1h') {
-            au.assert(date.getTime() % HOUR === 0, 'Expected timestamp to aligned to hour candle size in UTC')
-          }
-
-          if (interval === '1d') {
-            au.assert(date.getTime() % MINUTE === 0, 'Expected timestamp to aligned to minute candle size in UTC')
-          }
-        })
-
-        candles.forEach(c => {
-          au.assertNumericStringProperty(c, 'open')
-
-          au.assertNumericStringProperty(c, 'high')
-          au.assert(parseFloat(c.high) >= parseFloat(c.open), 'Expected high to be greater than or equal to open')
-          au.assert(parseFloat(c.high) >= parseFloat(c.close), 'Expected high to be greater than or equal to close')
-          au.assert(parseFloat(c.high) >= parseFloat(c.low), 'Expected high to be greater than or equal to low')
-
-          au.assertNumericStringProperty(c, 'low')
-          au.assert(parseFloat(c.low) > 0, 'Expected low to be greater than 0')
-          au.assert(parseFloat(c.low) <= parseFloat(c.open), 'Expected low to be less than or equal to open')
-          au.assert(parseFloat(c.low) <= parseFloat(c.close), 'Expected low to be less than or equal to close')
-          au.assert(parseFloat(c.low) <= parseFloat(c.high), 'Expected low to be less than or equal to high')
-
-          au.assertNumericStringProperty(c, 'close');
-
-          if (c.volume) {
-            au.assertNumericStringProperty(c, 'volume');
-            au.assertNumericStringProperty(c, 'volume_quote', { required: false });
-            au.assert(parseFloat(c.volume) >= 0, 'Expected volume to be greater than or equal to 0');
-          } else {
-            au.assertNumericStringProperty(c, 'volume_quote');
-            au.assertNumericStringProperty(c, 'volume', { required: false });
-            au.assert(parseFloat(c.volume_quote) >= 0, 'Expected volume to be greater than or equal to 0');
-          }
-        });
       }
-    } catch (err) {
-      console.log(`FAILED: URL ${uri || err.stack} failed with "${err.message}"`)
-
-      throw err
     }
   },
 


### PR DESCRIPTION
This PR makes the candles audit run through all the markets until it either times out or passes. This is to compensate for currencies with low trade activity that fail due to less than expected # of candles for an interval.