### PR TITLE
Relax candles audit

### DIFF
--- a/lib/audit/test/audit.js
+++ b/lib/audit/test/audit.js
@@ -34,11 +34,11 @@ module.exports = {
 
         au.assertStringProperty(this.info, 'location', { required: true })
         au.assertURLProperty(this.info, 'logo', { required: true, https: true })
+        au.assertStringProperty(this.info, 'version', { required: true });
       }
 
       au.assertURLProperty(this.info, 'website', { required: true })
       au.assertStringProperty(this.info, 'twitter', { required: false })
-      au.assertStringProperty(this.info, 'version');
       if (au.assertProperty(this.info, 'capability', { required: false })) {
         au.assertPropertyType(this.info, 'capability', 'object')
         const capability = this.info.capability
@@ -419,98 +419,106 @@ module.exports = {
       return
     }
 
-    const market = markets[0]
     const intervals = ['1d', '1h', '1m']
-    let uri
+    let success = false
 
-    try {
+    for (let i = 0; i < markets.length && !success; i++) {
+      const market = markets[i]
+      let uri
+
       for (const interval of intervals) {
-        uri = `/candles?market=${encodeURIComponent(market.id)}&interval=${interval}`
+        try {
+          uri = `/candles?market=${encodeURIComponent(market.id)}&interval=${interval}`
 
-        const candles = await au.get(uri)
+          const candles = await au.get(uri)
 
-        const c = JSON.parse(JSON.stringify(candles)) // deep clone
-        let t = candles.map(c => c.timestamp)
-        let tSorted = c.map(c => c.timestamp).sort()
+          const c = JSON.parse(JSON.stringify(candles)) // deep clone
+          let t = candles.map(c => c.timestamp)
+          let tSorted = c.map(c => c.timestamp).sort()
 
-        au.assert(
-          JSON.stringify(t) === JSON.stringify(tSorted),
-          `Expected ${interval} candles to be sorted by timestamp ascending`
-        )
-
-        if (interval === '1d') {
-          au.assert(candles.length >= 7, 'Expected at least 7 1d candles')
           au.assert(
-            new Date(candles[candles.length - 1].timestamp).getTime() > new Date().getTime() - 2 * DAY,
-            'Expected last 1d candle to be within the last 48 hours'
+            JSON.stringify(t) === JSON.stringify(tSorted),
+            `Expected ${interval} candles to be sorted by timestamp ascending`
           )
-        }
-
-        if (interval === '1h') {
-          au.assert(candles.length >= 24, 'Expected at least 24 1h candles')
-          au.assert(
-            new Date(candles[candles.length - 1].timestamp).getTime() > new Date().getTime() - 2 * HOUR,
-            'Expected last 1h candle to be within the last 2 hours'
-          )
-        }
-
-        if (interval === '1m') {
-          au.assert(candles.length >= 60, 'Expected at least 60 1m candles')
-          au.assert(
-            new Date(candles[candles.length - 1].timestamp).getTime() > new Date().getTime() - 10 * MINUTE,
-            'Expected last 1m candle to be within the last 10 minutes'
-          )
-        }
-
-        candles.forEach(c => {
-          au.assertTimestampProperty(c, 'timestamp')
-
-          let date = new Date(c.timestamp)
 
           if (interval === '1d') {
-            au.assert(date.getTime() % DAY === 0, 'Expected timestamp to aligned to day candle size in UTC')
+            au.assert(candles.length >= 7, 'Expected at least 7 1d candles')
+            au.assert(
+              new Date(candles[candles.length - 1].timestamp).getTime() > new Date().getTime() - 2 * DAY,
+              'Expected last 1d candle to be within the last 48 hours'
+            )
           }
 
           if (interval === '1h') {
-            au.assert(date.getTime() % HOUR === 0, 'Expected timestamp to aligned to hour candle size in UTC')
+            au.assert(candles.length >= 24, 'Expected at least 24 1h candles')
+            au.assert(
+              new Date(candles[candles.length - 1].timestamp).getTime() > new Date().getTime() - 2 * HOUR,
+              'Expected last 1h candle to be within the last 2 hours'
+            )
           }
 
-          if (interval === '1d') {
-            au.assert(date.getTime() % MINUTE === 0, 'Expected timestamp to aligned to minute candle size in UTC')
+          if (interval === '1m') {
+            au.assert(candles.length >= 60, 'Expected at least 60 1m candles')
+            au.assert(
+              new Date(candles[candles.length - 1].timestamp).getTime() > new Date().getTime() - 10 * MINUTE,
+              'Expected last 1m candle to be within the last 10 minutes'
+            )
           }
-        })
 
-        candles.forEach(c => {
-          au.assertNumericStringProperty(c, 'open')
+          candles.forEach(c => {
+            au.assertTimestampProperty(c, 'timestamp')
 
-          au.assertNumericStringProperty(c, 'high')
-          au.assert(parseFloat(c.high) >= parseFloat(c.open), 'Expected high to be greater than or equal to open')
-          au.assert(parseFloat(c.high) >= parseFloat(c.close), 'Expected high to be greater than or equal to close')
-          au.assert(parseFloat(c.high) >= parseFloat(c.low), 'Expected high to be greater than or equal to low')
+            let date = new Date(c.timestamp)
 
-          au.assertNumericStringProperty(c, 'low')
-          au.assert(parseFloat(c.low) > 0, 'Expected low to be greater than 0')
-          au.assert(parseFloat(c.low) <= parseFloat(c.open), 'Expected low to be less than or equal to open')
-          au.assert(parseFloat(c.low) <= parseFloat(c.close), 'Expected low to be less than or equal to close')
-          au.assert(parseFloat(c.low) <= parseFloat(c.high), 'Expected low to be less than or equal to high')
+            if (interval === '1d') {
+              au.assert(date.getTime() % DAY === 0, 'Expected timestamp to aligned to day candle size in UTC')
+            }
 
-          au.assertNumericStringProperty(c, 'close');
+            if (interval === '1h') {
+              au.assert(date.getTime() % HOUR === 0, 'Expected timestamp to aligned to hour candle size in UTC')
+            }
 
-          if (c.volume) {
-            au.assertNumericStringProperty(c, 'volume');
-            au.assertNumericStringProperty(c, 'volume_quote', { required: false });
-            au.assert(parseFloat(c.volume) >= 0, 'Expected volume to be greater than or equal to 0');
-          } else {
-            au.assertNumericStringProperty(c, 'volume_quote');
-            au.assertNumericStringProperty(c, 'volume', { required: false });
-            au.assert(parseFloat(c.volume_quote) >= 0, 'Expected volume to be greater than or equal to 0');
+            if (interval === '1d') {
+              au.assert(date.getTime() % MINUTE === 0, 'Expected timestamp to aligned to minute candle size in UTC')
+            }
+          })
+
+          candles.forEach(c => {
+            au.assertNumericStringProperty(c, 'open')
+
+            au.assertNumericStringProperty(c, 'high')
+            au.assert(parseFloat(c.high) >= parseFloat(c.open), 'Expected high to be greater than or equal to open')
+            au.assert(parseFloat(c.high) >= parseFloat(c.close), 'Expected high to be greater than or equal to close')
+            au.assert(parseFloat(c.high) >= parseFloat(c.low), 'Expected high to be greater than or equal to low')
+
+            au.assertNumericStringProperty(c, 'low')
+            au.assert(parseFloat(c.low) > 0, 'Expected low to be greater than 0')
+            au.assert(parseFloat(c.low) <= parseFloat(c.open), 'Expected low to be less than or equal to open')
+            au.assert(parseFloat(c.low) <= parseFloat(c.close), 'Expected low to be less than or equal to close')
+            au.assert(parseFloat(c.low) <= parseFloat(c.high), 'Expected low to be less than or equal to high')
+
+            au.assertNumericStringProperty(c, 'close');
+
+            if (c.volume) {
+              au.assertNumericStringProperty(c, 'volume');
+              au.assertNumericStringProperty(c, 'volume_quote', { required: false });
+              au.assert(parseFloat(c.volume) >= 0, 'Expected volume to be greater than or equal to 0');
+            } else {
+              au.assertNumericStringProperty(c, 'volume_quote');
+              au.assertNumericStringProperty(c, 'volume', { required: false });
+              au.assert(parseFloat(c.volume_quote) >= 0, 'Expected volume to be greater than or equal to 0');
+            }
+          });
+
+          success = true
+        } catch (err) {
+          console.log(`FAILED: URL ${uri || err.stack} failed with "${err.message}"`)
+
+          if (i === markets.length - 1) {
+            throw err
           }
-        });
+        }
       }
-    } catch (err) {
-      console.log(`FAILED: URL ${uri || err.stack} failed with "${err.message}"`)
-
-      throw err
     }
   },
 


### PR DESCRIPTION
This change allows multiple markets to be audited instead of just the first market. All of the markets' candles will be checked until either the audit passes or the auditor times out (at 30s). 